### PR TITLE
SSR title/meta with react-helmet

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "morgan": "^1.8.1",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
+    "react-helmet": "^5.1.3",
     "react-redux": "^5.0.4",
     "react-router-dom": "^4.1.1",
     "redux": "^3.6.0"

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,8 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Server Side Rendering - Create React App</title>
+    {{HELMET_TITLE}}
+    {{HELMET_META}}
   </head>
   <body>
     <noscript>		

--- a/server/universal.js
+++ b/server/universal.js
@@ -2,6 +2,7 @@ const path = require('path')
 const fs = require('fs')
 
 const React = require('react')
+import { Helmet } from 'react-helmet'
 const {Provider} = require('react-redux')
 const {renderToString} = require('react-dom/server')
 const {StaticRouter} = require('react-router-dom')
@@ -34,8 +35,13 @@ module.exports = function universalLoader(req, res) {
       // Somewhere a `<Redirect>` was rendered
       redirect(301, context.url)
     } else {
+      const helmet = Helmet.renderStatic()
       // we're good, send the response
-      const RenderedApp = htmlData.replace('{{SSR}}', markup)
+      const RenderedApp = htmlData
+        .replace('{{SSR}}', markup)
+        .replace('{{HELMET_TITLE}}', helmet.title.toString())
+        .replace('{{HELMET_META}}', helmet.meta.toString())
+
       res.send(RenderedApp)
     }
   })

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import { Switch, Route } from 'react-router-dom'
+import { Helmet } from 'react-helmet'
 import FirstPage from './FirstPage'
 import SecondPage from './SecondPage'
 import NoMatch from '../components/NoMatch'
@@ -8,6 +9,10 @@ export default class App extends Component {
   render(){
     return (
       <div>
+        <Helmet defaultTitle="ssr-create-react-app-v2" titleTemplate="%s - ssr-create-react-app-v2">
+          <meta name="description" content="This is the v2, its much better written, and uses react-router v4, which is actually pretty nice" />
+        </Helmet>
+
         <h1>Server Side Rendering with Create React App v2</h1>
         <p>Hey, so I've rewritten this example with react-router v4</p>
         <p>This code is on github: <a href='https://github.com/ayroblu/ssr-create-react-app-v2'>https://github.com/ayroblu/ssr-create-react-app-v2</a></p>

--- a/src/containers/FirstPage.js
+++ b/src/containers/FirstPage.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { Helmet } from 'react-helmet'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 
@@ -11,6 +12,10 @@ class FirstPage extends Component {
     const b64 = this.props.staticContext ? 'wait for it' : window.btoa('wait for it')
     return (
       <div className='bold'>
+        <Helmet>
+          <title>First Page</title>
+        </Helmet>
+
         <h2>First Page</h2>
         <p>{`Email: ${this.props.user.email}`}</p>
         <p>{`b64: ${b64}`}</p>


### PR DESCRIPTION
Provides an example implementation of [`react-helmet`](https://github.com/nfl/react-helmet) including pre-rendering on the server.

I don't have *yarn* installed so I couldn't update the lock-file.

In development mode, the *{{HELMET_%}}* strings do not get replaced and therefore show on the top of the document. I tried `<!--{{HELMET_%}}-->` (and the same in the `replace` function), but `react-scripts` removes comments in the `build` command, so there was nothing to replace. Maybe someone has an idea on how to solve this better?

Ref #10