### PR TITLE
Server: Custom status codes (404 on NoMatch)

### DIFF
--- a/server/universal.js
+++ b/server/universal.js
@@ -36,7 +36,7 @@ module.exports = function universalLoader(req, res) {
     } else {
       // we're good, send the response
       const RenderedApp = htmlData.replace('{{SSR}}', markup)
-      res.send(RenderedApp)
+      res.status(context.statusCode || 200).send(RenderedApp)
     }
   })
 }

--- a/src/components/NoMatch.js
+++ b/src/components/NoMatch.js
@@ -1,7 +1,19 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 //import './App.css'
 
 class NoMatch extends Component {
+  static contextTypes = {
+    router: PropTypes.shape({
+      staticContext: PropTypes.object
+    }).isRequired
+  }
+
+  componentWillMount() {
+    if (this.context.router.staticContext)
+      this.context.router.staticContext.statusCode = 404
+  }
+
   render() {
     return (
       <div>


### PR DESCRIPTION
Example on how to return custom status codes, like a 404 on the NoMatch component.

By programmatically accessing the routers `staticContext` that is passed down by `StaticRouter` as of https://github.com/ReactTraining/react-router/commit/bb663793717ab14fb738d70d752ab0f424dcadce.