### PR TITLE
Fixes error: 'redirect is not defined'

### DIFF
--- a/server/universal.js
+++ b/server/universal.js
@@ -32,7 +32,7 @@ module.exports = function universalLoader(req, res) {
 
     if (context.url) {
       // Somewhere a `<Redirect>` was rendered
-      redirect(301, context.url)
+      res.redirect(301, context.url)
     } else {
       // we're good, send the response
       const RenderedApp = htmlData.replace('{{SSR}}', markup)


### PR DESCRIPTION
Encountered 'redirect is not defined' error when rendering `<Redirect>`. 

This appears to resolve the issue.